### PR TITLE
[giac] embedded inequations in solve: must revert for evaluation

### DIFF
--- a/src/giac/cpp/k_csdk.c
+++ b/src/giac/cpp/k_csdk.c
@@ -1145,7 +1145,7 @@ int ascii_get(int* adaptive_cursor_state){
   // Special chars
   if (isKeyPressed(KEY_NSPIRE_SCRATCHPAD)) return SHIFTCTRL(KEY_CTRL_SETUP,KEY_LOAD,KEY_SAVE);
   if (isKeyPressed(KEY_NSPIRE_VAR)) return SHIFTCTRL(KEY_CTRL_VARS,KEY_CHAR_FACTOR,KEY_CHAR_STORE);
-  if (isKeyPressed(KEY_NSPIRE_DOC))		return SHIFT(KEY_CTRL_MENU,KEY_CTRL_SD);
+  if (isKeyPressed(KEY_NSPIRE_DOC))		return SHIFTCTRL(KEY_CTRL_MENU,KEY_CTRL_SD,KEY_CTRL_INS);
   if (isKeyPressed(KEY_NSPIRE_CAT))		return KEY_BOOK;
   if (isKeyPressed(KEY_NSPIRE_DEL))		return SHIFTCTRL(KEY_CTRL_DEL,KEY_CTRL_DEL,KEY_CTRL_AC);
   if (isKeyPressed(KEY_NSPIRE_RET))		return KEY_CTRL_EXE;

--- a/src/giac/cpp/kadd.cc
+++ b/src/giac/cpp/kadd.cc
@@ -749,6 +749,7 @@ int khicas_addins_menu(GIAC_CONTEXT){
 	  ptr=strcpy(ptr,electroneg+4)+strlen(ptr);
 	}
 	copy_clipboard(console_buf,true);
+        return KEY_CTRL_PASTE;        
 	// return Console_Input(console_buf);
       }
       if (smallmenu.selection==4){
@@ -764,6 +765,7 @@ int khicas_addins_menu(GIAC_CONTEXT){
 	if (c>=0){
 	  char buf[2]={c,0};
 	  copy_clipboard(buf,true);
+          return KEY_CTRL_PASTE;
 	}
 	break;
       }

--- a/src/giac/cpp/kdisplay.cc
+++ b/src/giac/cpp/kdisplay.cc
@@ -19288,6 +19288,8 @@ static void display(textArea *text, int &isFirstDraw, int &totalTextY, int &scro
         int res=khicas_addins_menu(contextptr);
         if (res==KEY_CTRL_MENU)
           return res;
+        if (res==KEY_CTRL_PASTE)
+          Console_Input((const char *) paste_clipboard());
         Console_Disp(1,contextptr);
         return CONSOLE_SUCCEEDED;
       }


### PR DESCRIPTION
calculator ports: shortcut ctrl-doc (insert char on nspire), fix chartable and periodic table (copy clipboad)

git-svn-id: https://dev.geogebra.org/svn/trunk/geogebra/giac@70160 23ce0884-8a58-47d3-bc5c-ddf1cd5b9f9e